### PR TITLE
Remove BUILD_DEPENDS in src/dkms.conf

### DIFF
--- a/src/dkms.conf
+++ b/src/dkms.conf
@@ -48,7 +48,6 @@ fi
 # Module name, source and destination directories, and build command-line
 BUILT_MODULE_NAME[0]="nvidia-fs"
 DEST_MODULE_LOCATION[0]="/kernel/fs/nvidia-fs/"
-BUILD_DEPENDS[0]="nvidia"
 MAKE[0]="'make' -j32 KVER=${kernelver} IGNORE_CC_MISMATCH='1'"
 REMAKE_INITRD=yes
 


### PR DESCRIPTION
The BUILD_DEPENDS[0]="nvidia" in src/dkms.conf will cause dkms autoinstall fail if we don't have the nvidia driver installed by dkms. Removing this line benefits someone who has the nvidia driver which is not installed by dkms.