### PR TITLE
A collection of warning fixes

### DIFF
--- a/src/nvfs-core.c
+++ b/src/nvfs-core.c
@@ -924,8 +924,9 @@ static inline bool unsigned_offsets(struct file *file)
         return file->f_mode & FMODE_UNSIGNED_OFFSET;
 }
 
-int nvfs_rw_verify_area(int read_write, struct file *file,
-		char __user *buf, const loff_t *ppos, size_t count)
+static int nvfs_rw_verify_area(int read_write, struct file *file,
+			       char __user *buf, const loff_t *ppos,
+			       size_t count)
 {
         struct inode *inode;
         loff_t pos;

--- a/src/nvfs-core.h
+++ b/src/nvfs-core.h
@@ -44,8 +44,12 @@
 
 #include <linux/list.h>
 
+#ifndef MAX
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#endif
+#ifndef MIN
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#endif
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/src/nvfs-dma.c
+++ b/src/nvfs-dma.c
@@ -737,9 +737,9 @@ static int nvfs_dma_map_sg_attrs(struct device *device,
 	return nvfs_dma_map_sg_attrs_internal(device, sglist, nents, dma_dir, attrs, false);
 }
 #ifdef NVFS_ENABLE_KERN_RDMA_SUPPORT
-int nvfs_get_gpu_sglist_rdma_info(struct scatterlist *sglist,
-				int nents,
-				struct nvfs_rdma_info *rdma_infop)
+static int nvfs_get_gpu_sglist_rdma_info(struct scatterlist *sglist,
+					 int nents,
+					 struct nvfs_rdma_info *rdma_infop)
 {
 	struct scatterlist *sg = NULL;
 	struct page *page;

--- a/src/nvfs-pci.c
+++ b/src/nvfs-pci.c
@@ -161,7 +161,7 @@ unsigned int _lookup_index_entry(uint64_t pcidevinfo,
  *  @params  : pci device info of the gpu
  *  @returns : index
  */
-unsigned int nvfs_create_gpu_hash_entry(uint64_t pdevinfo)
+static unsigned int nvfs_create_gpu_hash_entry(uint64_t pdevinfo)
 {
 	if (!pdevinfo)
 		return UINT_MAX;
@@ -174,7 +174,7 @@ unsigned int nvfs_create_gpu_hash_entry(uint64_t pdevinfo)
  *  @params  : pci device info of the peer device
  *  @returns : index
  */
-unsigned int nvfs_create_peer_hash_entry(uint64_t pdevinfo)
+static unsigned int nvfs_create_peer_hash_entry(uint64_t pdevinfo)
 {
 	if (!pdevinfo)
 		return UINT_MAX;
@@ -206,7 +206,7 @@ uint64_t nvfs_lookup_gpu_hash_index_entry(unsigned int index)
  *  @params  : pci device info of peer device
  *  @returns : hash index
  */
-unsigned int nvfs_get_peer_hash_index(uint64_t pdevinfo)
+static unsigned int nvfs_get_peer_hash_index(uint64_t pdevinfo)
 {
 	return _lookup_index_entry(pdevinfo, peer_info_table, MAX_PEER_DEVS);
 }
@@ -729,7 +729,7 @@ void nvfs_update_peer_usage(unsigned int gpu_index, u64 peer_pdevinfo) {
  *  @params  : distance to match
  *  @returns : count
  */
-uint64_t nvfs_aggregate_peer_usage_by_distance(unsigned int gpu_index, unsigned int pci_dist) {
+static uint64_t nvfs_aggregate_peer_usage_by_distance(unsigned int gpu_index, unsigned int pci_dist) {
 	unsigned int i;
 	uint64_t count = 0;
 	if (unlikely(gpu_index >= MAX_GPU_DEVS)) {

--- a/src/nvfs-proc.c
+++ b/src/nvfs-proc.c
@@ -38,7 +38,7 @@
 extern struct module_entry modules_list[];
 extern struct mutex nvfs_module_mutex;
 
-int nvfs_modules_show(struct seq_file *m, void *v)
+static int nvfs_modules_show(struct seq_file *m, void *v)
 {
 	int i;
 	struct module_entry *mod_entry;

--- a/src/nvfs-rdma.c
+++ b/src/nvfs-rdma.c
@@ -27,6 +27,7 @@
 #include "nvfs-core.h"
 #include "nvfs-dma.h"
 #include "nvfs-mmap.h"
+#include "nvfs-rdma.h"
 
 
 int nvfs_set_rdma_reg_info_to_mgroup(


### PR DESCRIPTION
This pull request contains a lots of fixes related to warnings reported by the compiler (it can have even more).

It changes:
- Some function definitions to `static`  to avoid the requirement to define a prototype (they are all used locally by its own X file).
- Some guards check to `MAX()` and `MIN()` definition.
- Some prototype warnings due to the missing inclusion of file `nvfs-rdma.h`.